### PR TITLE
Fix parameter syntax with sh command in deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
                     sh "mvn javadoc:aggregate -B -DskipTests -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS"
                     script {
                         if(params.RELEASE == true) {
-                            sh "mvn deploy -B -DskipTests -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS -Dgpg.secretKeyring=$ION_GPG_KEYRING -Dgpg.publicKeyring=$ION_GPG_KEYRING" -Prelease
+                            sh "mvn deploy -B -DskipTests -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS -Dgpg.secretKeyring=$ION_GPG_KEYRING -Dgpg.publicKeyring=$ION_GPG_KEYRING -Prelease"
                         } else {
                             sh "mvn deploy -B -DskipTests -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS"
                         }


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where the `-Prelease` parameter was outside of the quotes for the `mvn` command in the deploy pipeline stage and was causing build errors.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
 @cjlange
 @josephthweatt
 @figliold

#### How should this be tested? (List steps with links to updated documentation)
Run a release build on Jenkins and verify that it passes the deploy stage.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
