### PR TITLE
Remove batch mode parameter from release deploys to fix issue with GP…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,7 @@ pipeline {
                     sh "mvn javadoc:aggregate -B -DskipTests -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS"
                     script {
                         if(params.RELEASE == true) {
-                            sh "mvn deploy -B -DskipTests -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS -Dgpg.secretKeyring=$ION_GPG_KEYRING -Dgpg.publicKeyring=$ION_GPG_KEYRING -Dgpg.passphraseServerId=\"ion-signing\" -Prelease"
+                            sh "mvn deploy -DskipTests -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS -Dgpg.secretKeyring=$ION_GPG_KEYRING -Dgpg.publicKeyring=$ION_GPG_KEYRING -Dgpg.passphraseServerId=\"ion-signing\" -Prelease"
                         } else {
                             sh "mvn deploy -B -DskipTests -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS"
                         }


### PR DESCRIPTION
…G plugin

#### What does this PR do?
Removes the `-B` parameter from the Maven deploy command for release builds to determine if it it's the reason for the GPG errors seen in the build logs.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
 @cjlange
 @josephthweatt

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
