### PR TITLE
Upgrade jackson-databind to 2.10.0.pr3 to fix vulnerability issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <guava.version>28.0-jre</guava.version>
         <hibernate.validator.version>6.0.17.Final</hibernate.validator.version>
         <jackson.version>2.9.9</jackson.version>
-        <jackson.databind.version>2.10.0.pr2</jackson.databind.version>
+        <jackson.databind.version>2.10.0.pr3</jackson.databind.version>
         <jackson.databind.nullable.version>0.2.0</jackson.databind.nullable.version>
         <javax.servlet.version>4.0.1</javax.servlet.version>
         <okio.version>1.13.0</okio.version>


### PR DESCRIPTION
#### What does this PR do?

Upgrades the version of `jackson-databind` due to the security vulnerability reported here: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-467014. This upgrade will fix the failing CI build.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
 @cjlange 
 @josephthweatt
 @brendan-hofmann
 @figliold
 @mcalcote

#### How should this be tested? (List steps with links to updated documentation)

Verify that the build passes on CircleCI with no warnings from Snyk.

#### Any background context you want to provide?

https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-467014

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
