### PR TITLE
The API for Polling

### DIFF
--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -336,7 +336,7 @@ components:
             An array of the information for each metadata type that will be provided from the
             transformation request. NOTE this could be empty.
           type: array
-          minItems: 1
+          minItems: 0
           uniqueItems: true
           items:
             $ref: '#/components/schemas/MetadataInformation'
@@ -374,7 +374,7 @@ components:
     TransformRequest:
       type: object
       required:
-        - location
+        - currentLocation
         - metacardLocation
         - finalLocation
       properties:

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -17,7 +17,7 @@ info:
   version: ${project.version}
   title: Transformation API Specification
   description: >
-    The Transformation API allows files to be transformed into discovery metadata and other supporting products.
+    The Transformation API allows resources to be transformed into discovery metadata and other supporting products.
   contact:
     name: Connexta
   license:
@@ -33,15 +33,15 @@ paths:
       - $ref: '#/components/parameters/AcceptVersion'
     post:
       summary: Submit transformation request
-      description: A request to transform an intel resource into discovery metadata and other supporting products.
+      description: A request to transform resources into discovery metadata and other supporting products.
       operationId: transform
       tags:
         - transform
       requestBody:
         $ref: '#/components/requestBodies/TransformRequest'
       responses:
-        '202':
-          $ref: '#/components/responses/Accepted'
+        '201':
+          $ref: '#/components/responses/Created'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -66,7 +66,14 @@ paths:
         - transform
       responses:
         '200':
-          $ref: '#/components/responses/TransformationResponse'
+          description: Information on each of the metadata types that came out of the transformation.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransformationPollResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -88,7 +95,10 @@ paths:
         - transform
       responses:
         '204':
-          $ref: '#/components/responses/TransformationDeletedResponse'
+          description: The transformation request was successfully deleted.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -141,27 +151,15 @@ components:
           schema:
             $ref: '#/components/schemas/TransformRequest'
   responses:
-    Accepted:
-      description: The transformation request was accepted for processing.
+    Created:
+      description: >
+        The transformation request was accepted for processing. The URI for polling the status is
+        returned in the Location header of the response.
       headers:
         Content-Version:
           $ref: '#/components/headers/ContentVersion'
         Location:
           $ref: '#/components/headers/Location'
-    TransformationResponse:
-      description: Information on each of the metadata types that came out of the transformation.
-      headers:
-        Content-Version:
-          $ref: '#/components/headers/ContentVersion'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/MetadataInformationResponse'
-    TransformationDeletedResponse:
-      description: The transformation request was successfully deleted.
-      headers:
-        Content-Version:
-          $ref: '#/components/headers/ContentVersion'
     MetadataContentResponse:
       description: Successfully retrieved.
       headers:
@@ -321,19 +319,25 @@ components:
       maxLength: 80
       pattern: '^([1-9]([0-9]+)?)\.(0|([1-9]([0-9]+)?))(\.(0|([1-9]([0-9]+)?))(-.*)?)?$'
       example: 1.2, 2.4.3, 0.2.5-SNAPSHOT
-    MetadataInformationResponse:
+    TransformationPollResponse:
       type: object
       required:
         - transformationStatus
         - metadataInformations
       properties:
         transformationStatus:
+          description: This is an aggregated status.
           $ref: '#/components/schemas/Status'
         errorMessage:
           description: An optional error message in the case the transformation failed.
           $ref: '#/components/schemas/ErrorMessage'
         metadataInformations:
+          description: >
+            An array of the information for each metadata type that will be provided from the
+            transformation request. NOTE this could be empty.
           type: array
+          minItems: 1
+          uniqueItems: true
           items:
             $ref: '#/components/schemas/MetadataInformation'
     MetadataInformation:
@@ -371,31 +375,24 @@ components:
       type: object
       required:
         - location
-        - mimeType
         - metacardLocation
+        - finalLocation
       properties:
         currentLocation:
           description: >
-            This URI must support HTTP GET to retrieve the file and HTTP PUT with attachment at
-            location/metadata/{metadataType} to store metadata, where {metadataType} is restricted
-            to alphanumeric characters.
+            This URI must support HTTP GET to retrieve the file. This MUST be available until the
+            transformation request is "Done".
           type: string
           format: uri
           example: https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3
         finalLocation:
           description: >
-            This is a URI that will only be used by the Transform service to put on the transformed
-            metadata for the "resource download location".
+            This URI will not actually be called by the Transform service. It will only be used by
+            the Transform service to put in the transformed metadata for the
+            "resource download location".
           type: string
-          minLength: 1
-          maxLength: 2048
+          format: uri
           example: https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3
-        mimeType:
-          type: string
-          description: The mime type of the file that can be retrieved at the location.
-          minLength: 1
-          maxLength: 255
-          example: application/xml
         metacardLocation:
           description: >
             This URI must support HTTP GET to retrieve the metacard xml.

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -65,9 +65,7 @@ paths:
       tags:
         - transform
       responses:
-        '204':
-          $ref: '#/components/responses/TransformationInProgress'
-        '201':
+        '200':
           $ref: '#/components/responses/MetadataInformationResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -77,8 +75,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/TransformationFailed'
         '501':
           $ref: '#/components/responses/NotImplemented'
         'default':
@@ -153,39 +149,19 @@ components:
         Location:
           $ref: '#/components/headers/Location'
     MetadataInformationResponse:
-      description: Transform complete. Returning metadata locations.
+      description: Information on each of the metadata types that came out of the transformation.
       headers:
         Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/MetadataInformation'
+            $ref: '#/components/schemas/MetadataInformationResponse'
     TransformationDeletedResponse:
       description: The transformation request was successfully deleted.
       headers:
         Content-Version:
           $ref: '#/components/headers/ContentVersion'
-    TransformationInProgress:
-      description: The transformation is in progress.
-      headers:
-        Content-Version:
-          $ref: '#/components/headers/ContentVersion'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    TransformationFailed:
-      description: The transformation failed.
-      headers:
-        Content-Version:
-          $ref: '#/components/headers/ContentVersion'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
     MetadataContentResponse:
       description: Successfully retrieved.
       headers:
@@ -341,27 +317,48 @@ components:
       maxLength: 80
       pattern: '^([1-9]([0-9]+)?)\.(0|([1-9]([0-9]+)?))(\.(0|([1-9]([0-9]+)?))(-.*)?)?$'
       example: 1.2, 2.4.3, 0.2.5-SNAPSHOT
+    MetadataInformationResponse:
+      type: object
+      required:
+        - transformationStatus
+        - metadataInformations
+      properties:
+        transformationStatus:
+          $ref: '#/components/schemas/Status'
+        metadataInformations:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetadataInformation'
     MetadataInformation:
       type: object
+      required:
+        - metadataType
+        - transformationStatus
       properties:
         metadataType:
           $ref: '#/components/schemas/MetadataType'
+        transformationStatus:
+          $ref: '#/components/schemas/Status'
         location:
-          description: The URI for where the metadata is located.
+          description: The URI for where the metadata is located. NOTE this will not be populated until the transformationStatus is Complete.
           type: string
           format: uri
           minLength: 1
           maxLength: 2048
           example: 'https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3'
-        timestamp:
+        transformedTimestamp:
           type: string
           format: date-time
-          description: The server time when the metadata was generated.
+          description: The server time when the metadata was generated. NOTE this will not be populated until the transformationStatus is Complete.
           example: 2019-05-09T14:47:13.101+0000
     MetadataType:
       description: The type of metadata.
       type: string
       enum: [irm]
+    Status:
+      description: The status of the operation.
+      type: string
+      enum: [In Progress, Done, Failed]
     TransformRequest:
       type: object
       required:

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -33,7 +33,7 @@ paths:
       - $ref: '#/components/parameters/AcceptVersion'
     post:
       summary: Submit transformation request
-      description: A request to transform a file into discovery metadata and other supporting products.
+      description: A request to transform an intel resource into discovery metadata and other supporting products.
       operationId: transform
       tags:
         - transform
@@ -65,32 +65,10 @@ paths:
       tags:
         - transform
       responses:
-        '200':
-          description: The transform is still in progress.
-          headers:
-            Content-Version:
-              $ref: '#/components/headers/ContentVersion'
+        '204':
+          $ref: '#/components/responses/TransformationInProgress'
         '201':
-          description: Transform complete. Returning metadata locations.
-          headers:
-            Content-Version:
-              $ref: '#/components/headers/ContentVersion'
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    format:
-                      $ref: '#/components/schemas/MetadataFormat'
-                    location:
-                      description: The URI for where the metadata is located.
-                      type: string
-                      format: uri
-                      minLength: 1
-                      maxLength: 2048
-                      example: 'https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3'
+          $ref: '#/components/responses/MetadataInformationResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -100,14 +78,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
-          description: The transformation failed.
-          headers:
-            Content-Version:
-              $ref: '#/components/headers/ContentVersion'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/TransformationFailed'
         '501':
           $ref: '#/components/responses/NotImplemented'
         'default':
@@ -121,10 +92,7 @@ paths:
         - transform
       responses:
         '204':
-          description: The transformation request was successfully deleted.
-          headers:
-            Content-Version:
-              $ref: '#/components/headers/ContentVersion'
+          $ref: '#/components/responses/TransformationDeletedResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -137,15 +105,15 @@ paths:
           $ref: '#/components/responses/NotImplemented'
         'default':
           $ref: '#/components/responses/DefaultError'
-  /transform/{TransformId}/{MetadataFormat}:
+  /transform/{TransformId}/{MetadataType}:
     parameters:
       - $ref: '#/components/parameters/TransformId'
-      - name: MetadataFormat
+      - name: MetadataType
         in: path
         description: The metadata format ID.
         required: true
         schema:
-          $ref: '#/components/schemas/MetadataFormat'
+          $ref: '#/components/schemas/MetadataType'
     get:
       summary: Retrieve metadata.
       description: Used to retrieve the metadata for a transform request.
@@ -154,15 +122,7 @@ paths:
         - transform
       responses:
         '200':
-          description: Successfully retrieved.
-          headers:
-            Content-Version:
-              $ref: '#/components/headers/ContentVersion'
-          content:
-            text/plain:
-              schema:
-                type: string
-                description: The metadata contents.
+          $ref: '#/components/responses/MetadataContentResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -192,6 +152,51 @@ components:
           $ref: '#/components/headers/ContentVersion'
         Location:
           $ref: '#/components/headers/Location'
+    MetadataInformationResponse:
+      description: Transform complete. Returning metadata locations.
+      headers:
+        Content-Version:
+          $ref: '#/components/headers/ContentVersion'
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/MetadataInformation'
+    TransformationDeletedResponse:
+      description: The transformation request was successfully deleted.
+      headers:
+        Content-Version:
+          $ref: '#/components/headers/ContentVersion'
+    TransformationInProgress:
+      description: The transformation is in progress.
+      headers:
+        Content-Version:
+          $ref: '#/components/headers/ContentVersion'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    TransformationFailed:
+      description: The transformation failed.
+      headers:
+        Content-Version:
+          $ref: '#/components/headers/ContentVersion'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    MetadataContentResponse:
+      description: Successfully retrieved.
+      headers:
+        Content-Version:
+          $ref: '#/components/headers/ContentVersion'
+      content:
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+            description: The metadata contents.
     BadRequest:
       description: The client message could not be understood by the server due to invalid format or syntax.
       headers:
@@ -336,8 +341,25 @@ components:
       maxLength: 80
       pattern: '^([1-9]([0-9]+)?)\.(0|([1-9]([0-9]+)?))(\.(0|([1-9]([0-9]+)?))(-.*)?)?$'
       example: 1.2, 2.4.3, 0.2.5-SNAPSHOT
-    MetadataFormat:
-      description: The format of the metadata.
+    MetadataInformation:
+      type: object
+      properties:
+        metadataType:
+          $ref: '#/components/schemas/MetadataType'
+        location:
+          description: The URI for where the metadata is located.
+          type: string
+          format: uri
+          minLength: 1
+          maxLength: 2048
+          example: 'https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3'
+        timestamp:
+          type: string
+          format: date-time
+          description: The server time when the metadata was generated.
+          example: 2019-05-09T14:47:13.101+0000
+    MetadataType:
+      description: The type of metadata.
       type: string
       enum: [irm]
     TransformRequest:

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -66,7 +66,7 @@ paths:
         - transform
       responses:
         '200':
-          $ref: '#/components/responses/MetadataInformationResponse'
+          $ref: '#/components/responses/TransformationResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -148,7 +148,7 @@ components:
           $ref: '#/components/headers/ContentVersion'
         Location:
           $ref: '#/components/headers/Location'
-    MetadataInformationResponse:
+    TransformationResponse:
       description: Information on each of the metadata types that came out of the transformation.
       headers:
         Content-Version:
@@ -167,6 +167,11 @@ components:
       headers:
         Content-Version:
           $ref: '#/components/headers/ContentVersion'
+        Content-Length:
+          required: true
+          schema:
+            description: The length, in bytes, of the response body.
+            type: integer
       content:
         application/octet-stream:
           schema:
@@ -278,10 +283,6 @@ components:
       required: true
       schema:
         type: string
-        minLength: 32
-        maxLength: 32
-        pattern: '^[0-9a-zA-Z]+$'
-        example: 098asdfjh9as8dfh09sdfh0as9d8fha3
   headers:
     ContentVersion:
       description: >
@@ -302,13 +303,11 @@ components:
           summary: A development version
     Location:
       description: >
-        The URI that can be used to poll for readiness of the transformed file's discovery metadata and other supporting products.
+        The URI that can be used to retrieve the status of the transformation request.
       required: true
       schema:
         type: string
         format: uri
-        minLength: 1
-        maxLength: 500
   schemas:
     Version:
       description: Version number.
@@ -325,6 +324,9 @@ components:
       properties:
         transformationStatus:
           $ref: '#/components/schemas/Status'
+        errorMessage:
+          description: An optional error message in the case the transformation failed.
+          $ref: '#/components/schemas/ErrorMessage'
         metadataInformations:
           type: array
           items:
@@ -339,12 +341,13 @@ components:
           $ref: '#/components/schemas/MetadataType'
         transformationStatus:
           $ref: '#/components/schemas/Status'
+        errorMessage:
+          description: An optional error message in the case the transformation failed.
+          $ref: '#/components/schemas/ErrorMessage'
         location:
           description: The URI for where the metadata is located. NOTE this will not be populated until the transformationStatus is Complete.
           type: string
           format: uri
-          minLength: 1
-          maxLength: 2048
           example: 'https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3'
         transformedTimestamp:
           type: string
@@ -387,7 +390,7 @@ components:
           format: uri
           example: https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3
     ErrorResponse:
-      description: Error response message.
+      description: Error response.
       type: object
       required:
         - timestamp
@@ -424,6 +427,14 @@ components:
           description: The corresponding HTTP reason phrase.
           example: Bad Request
           minLength: 1
+        errorMessage:
+          $ref: '#/components/schemas/ErrorMessage'
+    ErrorMessage:
+      type: object
+      description: Error message.
+      required:
+        - message
+      properties:
         message:
           type: string
           description: Specific information about the error.
@@ -432,5 +443,5 @@ components:
         details:
           type: array
           items:
-           type: string
+            type: string
           description: Optional detailed information about the error.

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -32,7 +32,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/AcceptVersion'
     post:
-      summary: Transformation request
+      summary: Submit transformation request
       description: A request to transform a file into discovery metadata and other supporting products.
       operationId: transform
       tags:
@@ -54,7 +54,127 @@ paths:
           $ref: '#/components/responses/NotImplemented'
         default:
           $ref: '#/components/responses/DefaultError'
-
+  /transform/{TransformId}:
+    parameters:
+      - $ref: '#/components/parameters/TransformId'
+    get:
+      summary: Poll transformation request status
+      description: >
+        After posting a transformation request, the client can use the returned URI to poll for the transform's completion at this endpoint.
+      operationId: poll
+      tags:
+        - transform
+      responses:
+        '200':
+          description: The transform is still in progress.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
+        '201':
+          description: Transform complete. Returning metadata locations.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    format:
+                      $ref: '#/components/schemas/MetadataFormat'
+                    location:
+                      description: The URI for where the metadata is located.
+                      type: string
+                      format: uri
+                      minLength: 1
+                      maxLength: 2048
+                      example: 'https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          description: The transformation failed.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        'default':
+          $ref: '#/components/responses/DefaultError'
+    delete:
+      summary: Delete the transformation request
+      description: >
+        After retrieving the output of the transformation, the client should call this endpoint to remove the request.
+      operationId: delete
+      tags:
+        - transform
+      responses:
+        '204':
+          description: The transformation request was successfully deleted.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        'default':
+          $ref: '#/components/responses/DefaultError'
+  /transform/{TransformId}/{MetadataFormat}:
+    parameters:
+      - $ref: '#/components/parameters/TransformId'
+      - name: MetadataFormat
+        in: path
+        description: The metadata format ID.
+        required: true
+        schema:
+          $ref: '#/components/schemas/MetadataFormat'
+    get:
+      summary: Retrieve metadata.
+      description: Used to retrieve the metadata for a transform request.
+      operationId: retrieve
+      tags:
+        - transform
+      responses:
+        '200':
+          description: Successfully retrieved.
+          headers:
+            Content-Version:
+              $ref: '#/components/headers/ContentVersion'
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: The metadata contents.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+        'default':
+          $ref: '#/components/responses/DefaultError'
 components:
   requestBodies:
     TransformRequest:
@@ -68,12 +188,14 @@ components:
     Accepted:
       description: The transformation request was accepted for processing.
       headers:
-        'Content-Version':
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
+        Location:
+          $ref: '#/components/headers/Location'
     BadRequest:
       description: The client message could not be understood by the server due to invalid format or syntax.
       headers:
-        'Content-Version':
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
@@ -82,7 +204,7 @@ components:
     Unauthorized:
       description: The client could not be authenticated.
       headers:
-        'Content-Version':
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
@@ -91,7 +213,16 @@ components:
     Forbidden:
       description: The client is not authorized.
       headers:
-        'Content-Version':
+        Content-Version:
+          $ref: '#/components/headers/ContentVersion'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: The transform request could not be found.
+      headers:
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
@@ -100,7 +231,7 @@ components:
     InternalServerError:
       description: The server encountered an unexpected condition that prevented it from fulfilling the request.
       headers:
-        'Content-Version':
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
@@ -119,7 +250,7 @@ components:
 
         - 501004 - The provided minor version is not yet supported by the server
       headers:
-        'Content-Version':
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
@@ -129,7 +260,7 @@ components:
     DefaultError:
       description: Any other possible errors not currently known.
       headers:
-        'Content-Version':
+        Content-Version:
           $ref: '#/components/headers/ContentVersion'
       content:
         application/json:
@@ -158,7 +289,18 @@ components:
         dev:
           value: '1.2.0-SNAPSHOT'
           summary: A development version
-
+    TransformId:
+      name: TransformId
+      in: path
+      description: >
+        The ID of the transform request.
+      required: true
+      schema:
+        type: string
+        minLength: 32
+        maxLength: 32
+        pattern: '^[0-9a-zA-Z]+$'
+        example: 098asdfjh9as8dfh09sdfh0as9d8fha3
   headers:
     ContentVersion:
       description: >
@@ -177,7 +319,15 @@ components:
         dev:
           value: '1.2.0-SNAPSHOT'
           summary: A development version
-
+    Location:
+      description: >
+        The URI that can be used to poll for readiness of the transformed file's discovery metadata and other supporting products.
+      required: true
+      schema:
+        type: string
+        format: uri
+        minLength: 1
+        maxLength: 500
   schemas:
     Version:
       description: Version number.
@@ -186,6 +336,10 @@ components:
       maxLength: 80
       pattern: '^([1-9]([0-9]+)?)\.(0|([1-9]([0-9]+)?))(\.(0|([1-9]([0-9]+)?))(-.*)?)?$'
       example: 1.2, 2.4.3, 0.2.5-SNAPSHOT
+    MetadataFormat:
+      description: The format of the metadata.
+      type: string
+      enum: [irm]
     TransformRequest:
       type: object
       required:

--- a/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
+++ b/rest/specs/src/main/filtered-resources/openapi/openapi.yaml
@@ -167,10 +167,15 @@ components:
       headers:
         Content-Version:
           $ref: '#/components/headers/ContentVersion'
+        Content-Type:
+          required: true
+          schema:
+            description: The content type of the response body contents
+            type: string
         Content-Length:
           required: true
           schema:
-            description: The length, in bytes, of the response body.
+            description: The length, in bytes, of the response body contents.
             type: integer
       content:
         application/octet-stream:
@@ -369,13 +374,21 @@ components:
         - mimeType
         - metacardLocation
       properties:
-        location:
+        currentLocation:
           description: >
             This URI must support HTTP GET to retrieve the file and HTTP PUT with attachment at
             location/metadata/{metadataType} to store metadata, where {metadataType} is restricted
             to alphanumeric characters.
           type: string
           format: uri
+          example: https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3
+        finalLocation:
+          description: >
+            This is a URI that will only be used by the Transform service to put on the transformed
+            metadata for the "resource download location".
+          type: string
+          minLength: 1
+          maxLength: 2048
           example: https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3
         mimeType:
           type: string


### PR DESCRIPTION
#### What does this PR do?
Changes to the transformation API to account for storing the transformed metadata temporarily until the client can retrieve it.
From a high-level:
- Client POST's a Transformation request and gets a Location in the header.
- Client does a GET on the URI from the Location header.
    - If an error code, something went wrong (generalizing).
    - If a `200` status is returned, the transformation isn't finished yet. Poll this URI again.
    - If a `201` status is returned, the transformation is complete and the URI's for supported metadata formats is in the body of the response.
- Client does a GET on the metadata URI's returned.
- Client does a DELETE once it's done.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@connexta/i2o-architecture
@connexta/i2o-cdr 
@clockard 
