### PR TITLE
LORE-256 Separate TransformApi methods into their own interfaces

### DIFF
--- a/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiDelete.java
+++ b/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiDelete.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformation.rest.spring;
+
+import com.connexta.transformation.rest.models.ErrorResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * Implementations of the {@code TransformApiDelete} interface provide a mechanism to implement the
+ * rest DELETE endpoint. This interface was manually separated out from the generated
+ * TransformApi.java file and any changes must be updated here as well. This was done to allow the
+ * creation of separate controller classes along with what gets changed/added. This interface
+ * currently adds the throws Exception to the method signature.
+ */
+@Validated
+@Api(value = "transform", description = "the transform API")
+public interface TransformApiDelete {
+
+  @ApiOperation(
+      value = "Delete the transformation request",
+      nickname = "delete",
+      notes =
+          "After retrieving the output of the transformation, the client should call this endpoint to remove the request. ",
+      tags = {
+        "transform",
+      })
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 204, message = "The transformation request was successfully deleted."),
+        @ApiResponse(
+            code = 400,
+            message =
+                "The client message could not be understood by the server due to invalid format or syntax.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 401,
+            message = "The client could not be authenticated.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 403,
+            message = "The client is not authorized.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 404,
+            message = "The transform request could not be found.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 501,
+            message =
+                "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 200,
+            message = "Any other possible errors not currently known.",
+            response = ErrorResponse.class)
+      })
+  @RequestMapping(
+      value = "/transform/{TransformId}",
+      produces = {"application/json"},
+      method = RequestMethod.DELETE)
+  default ResponseEntity<Void> delete(
+      @ApiParam(value = "The ID of the transform request. ", required = true)
+          @PathVariable("TransformId")
+          String transformId)
+      throws Exception {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+}

--- a/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiPoll.java
+++ b/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiPoll.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformation.rest.spring;
+
+import com.connexta.transformation.rest.models.ErrorResponse;
+import com.connexta.transformation.rest.models.TransformationPollResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.NativeWebRequest;
+
+/**
+ * Implementations of the {@code TransformApiPoll} interface provide a mechanism to implement the
+ * rest GET/poll endpoint. This interface was manually separated out from the generated
+ * TransformApi.java file and any changes must be updated here as well. This was done to allow the
+ * creation of separate controller classes along with what gets changed/added. This interface
+ * currently adds the throws Exception to the method signature.
+ */
+@Validated
+@Api(value = "transform", description = "the transform API")
+public interface TransformApiPoll {
+
+  default Optional<NativeWebRequest> getRequest() {
+    return Optional.empty();
+  }
+
+  @ApiOperation(
+      value = "Poll transformation request status",
+      nickname = "poll",
+      notes =
+          "After posting a transformation request, the client can use the returned URI to poll for the transform's completion at this endpoint. ",
+      response = TransformationPollResponse.class,
+      tags = {
+        "transform",
+      })
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            code = 200,
+            message =
+                "Information on each of the metadata types that came out of the transformation.",
+            response = TransformationPollResponse.class),
+        @ApiResponse(
+            code = 400,
+            message =
+                "The client message could not be understood by the server due to invalid format or syntax.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 401,
+            message = "The client could not be authenticated.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 403,
+            message = "The client is not authorized.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 404,
+            message = "The transform request could not be found.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 501,
+            message =
+                "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 200,
+            message = "Any other possible errors not currently known.",
+            response = ErrorResponse.class)
+      })
+  @RequestMapping(
+      value = "/transform/{TransformId}",
+      produces = {"application/json"},
+      method = RequestMethod.GET)
+  default ResponseEntity<TransformationPollResponse> poll(
+      @ApiParam(value = "The ID of the transform request. ", required = true)
+          @PathVariable("TransformId")
+          String transformId)
+      throws Exception {
+    getRequest()
+        .ifPresent(
+            request -> {
+              for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {
+                if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                  ApiUtil.setExampleResponse(
+                      request,
+                      "application/json",
+                      "{  \"errorMessage\" : {    \"details\" : [ \"details\", \"details\" ],    \"message\" : \"Validation failed for object='systemInfo'.\"  },  \"metadataInformations\" : [ {    \"transformedTimestamp\" : \"2000-01-23T04:56:07.000+00:00\",    \"errorMessage\" : {      \"details\" : [ \"details\", \"details\" ],      \"message\" : \"Validation failed for object='systemInfo'.\"    },    \"location\" : \"https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3\"  }, {    \"transformedTimestamp\" : \"2000-01-23T04:56:07.000+00:00\",    \"errorMessage\" : {      \"details\" : [ \"details\", \"details\" ],      \"message\" : \"Validation failed for object='systemInfo'.\"    },    \"location\" : \"https://www.example.com/mis/30f14c6c1fc85cba12bfd093aa8f90e3\"  } ]}");
+                  break;
+                }
+              }
+            });
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+}

--- a/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiRetrieve.java
+++ b/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiRetrieve.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformation.rest.spring;
+
+import com.connexta.transformation.rest.models.ErrorResponse;
+import com.connexta.transformation.rest.models.MetadataType;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * Implementations of the {@code TransformApiRetrieve} interface provide a mechanism to implement
+ * the rest GET/retrieve endpoint. This interface was manually separated out from the generated
+ * TransformApi.java file and any changes must be updated here as well. This was done to allow the
+ * creation of separate controller classes along with what gets changed/added. This interface
+ * currently adds the throws Exception to the method signature.
+ */
+@Validated
+@Api(value = "transform", description = "the transform API")
+public interface TransformApiRetrieve {
+
+  @ApiOperation(
+      value = "Retrieve metadata.",
+      nickname = "retrieve",
+      notes = "Used to retrieve the metadata for a transform request.",
+      response = Resource.class,
+      tags = {
+        "transform",
+      })
+  @ApiResponses(
+      value = {
+        @ApiResponse(code = 200, message = "Successfully retrieved.", response = Resource.class),
+        @ApiResponse(
+            code = 400,
+            message =
+                "The client message could not be understood by the server due to invalid format or syntax.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 401,
+            message = "The client could not be authenticated.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 403,
+            message = "The client is not authorized.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 404,
+            message = "The transform request could not be found.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 501,
+            message =
+                "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 200,
+            message = "Any other possible errors not currently known.",
+            response = ErrorResponse.class)
+      })
+  @RequestMapping(
+      value = "/transform/{TransformId}/{MetadataType}",
+      produces = {"application/octet-stream", "application/json"},
+      method = RequestMethod.GET)
+  default ResponseEntity<Resource> retrieve(
+      @ApiParam(value = "The ID of the transform request. ", required = true)
+          @PathVariable("TransformId")
+          String transformId,
+      @ApiParam(value = "The metadata format ID.", required = true, allowableValues = "\"irm\"")
+          @PathVariable("MetadataType")
+          MetadataType metadataType)
+      throws Exception {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+}

--- a/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiTransform.java
+++ b/rest/servers/spring/src/main/java/com/connexta/transformation/rest/spring/TransformApiTransform.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformation.rest.spring;
+
+import com.connexta.transformation.rest.models.ErrorResponse;
+import com.connexta.transformation.rest.models.TransformRequest;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * Implementations of the {@code TransformApiTransform} interface provide a mechanism to implement
+ * the rest POST/transform endpoint. This interface was manually separated out from the generated
+ * TransformApi.java file and any changes must be updated here as well. This was done to allow the
+ * creation of separate controller classes along with what gets changed/added. This interface
+ * currently adds the throws Exception to the method signature.
+ */
+@Validated
+@Api(value = "transform", description = "the transform API")
+public interface TransformApiTransform {
+
+  @ApiOperation(
+      value = "Submit transformation request",
+      nickname = "transform",
+      notes =
+          "A request to transform resources into discovery metadata and other supporting products.",
+      tags = {
+        "transform",
+      })
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            code = 201,
+            message =
+                "The transformation request was accepted for processing. The URI for polling the status is returned in the Location header of the response. "),
+        @ApiResponse(
+            code = 400,
+            message =
+                "The client message could not be understood by the server due to invalid format or syntax.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 401,
+            message = "The client could not be authenticated.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 403,
+            message = "The client is not authorized.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 500,
+            message =
+                "The server encountered an unexpected condition that prevented it from fulfilling the request.",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 501,
+            message =
+                "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
+            response = ErrorResponse.class),
+        @ApiResponse(
+            code = 200,
+            message = "Any other possible errors not currently known.",
+            response = ErrorResponse.class)
+      })
+  @RequestMapping(
+      value = "/transform",
+      produces = {"application/json"},
+      consumes = {"application/json"},
+      method = RequestMethod.POST)
+  default ResponseEntity<Void> transform(
+      @ApiParam(
+              value =
+                  "The API version used by the client to produce the REST message. The client must accept responses marked with any minor versions after this one. This implies that all future minor versions of the message are backward compatible with all previous minor versions of the same message. ",
+              required = true)
+          @RequestHeader(value = "Accept-Version", required = true)
+          String acceptVersion,
+      @ApiParam(
+              value =
+                  "A request to transform a file into discovery metadata and other supporting products.",
+              required = true)
+          @Valid
+          @RequestBody
+          TransformRequest transformRequest)
+      throws Exception {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
This PR separates the TransformApi interface into 4 separate interfaces respectively for each method. This was done to better divide and also allow `throws Exception` to be added to the methods. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@austinsteffes 
@brendan-hofmann
@brjeter 
@kcover 
@paouelle 


#### How should this be tested? (List steps with links to updated documentation)
CI

#### Any background context you want to provide?
The `TransformApi` interface is a direct copy-paste of the generated file from the yaml file.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
